### PR TITLE
fix: исправлена опечатка "коменсации"

### DIFF
--- a/lib/domain/models/ci_scheme_model.dart
+++ b/lib/domain/models/ci_scheme_model.dart
@@ -15,5 +15,5 @@ abstract class CiSchemeModel with _$CiSchemeModel {
         name: proto.name,
       );
 
-  static const CiSchemeModel empty = CiSchemeModel(id: -1, name: 'Без коменсации');
+  static const CiSchemeModel empty = CiSchemeModel(id: -1, name: 'Без компенсации');
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -107,7 +107,7 @@
   "@addSeparationBtnText": {},
   "tournamentPageListOfPlayers": "Список участников",
   "@tournamentPageListOfPlayers": {},
-  "withoutCi": "Без коменсации",
+  "withoutCi": "Без компенсации",
   "@withoutCi": {},
   "ci": "Компенсация",
   "@ci": {},


### PR DESCRIPTION
Исправлена опечатка "Без коменсации" → "Без компенсации" в дропдауне Компенсация.

Фиксит https://github.com/Mafbase/mafbase-app/issues/17

Generated with [Claude Code](https://claude.ai/code)