### PR TITLE
feat(club): open club settings in a dialog on desktop

### DIFF
--- a/lib/ui/main/club_page/widgets/club_owners_bottom_sheet.dart
+++ b/lib/ui/main/club_page/widgets/club_owners_bottom_sheet.dart
@@ -2,10 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:seating_generator_web/app/di/repository_factory.dart';
 import 'package:seating_generator_web/common/theme/my_theme.dart';
 import 'package:seating_generator_web/common/widgets/confirm_dialog.dart';
+import 'package:seating_generator_web/common/widgets/custom_dialog.dart';
 import 'package:seating_generator_web/domain/models/user_model.dart';
 import 'package:seating_generator_web/domain/repositories/owners_repository.dart';
 import 'package:seating_generator_web/feature/administration_page/widgets/add_owner_dialog.dart';
 import 'package:seating_generator_web/utils.dart';
+import 'package:seating_generator_web/utils/widget_extensions.dart';
 
 class ClubOwnersBottomSheet {
   ClubOwnersBottomSheet._();
@@ -14,27 +16,37 @@ class ClubOwnersBottomSheet {
     BuildContext context, {
     required int clubId,
   }) {
+    // On desktop open a separate centered dialog window; on mobile keep the
+    // draggable bottom sheet.
+    if (!context.isMobile) {
+      return showDialog<void>(
+        context: context,
+        builder: (_) => _ClubOwnersBody(clubId: clubId, isDialog: true),
+      );
+    }
+
     return showModalBottomSheet(
       context: context,
       isScrollControlled: true,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
       ),
-      builder: (_) => _ClubOwnersBottomSheetBody(clubId: clubId),
+      builder: (_) => _ClubOwnersBody(clubId: clubId),
     );
   }
 }
 
-class _ClubOwnersBottomSheetBody extends StatefulWidget {
+class _ClubOwnersBody extends StatefulWidget {
   final int clubId;
+  final bool isDialog;
 
-  const _ClubOwnersBottomSheetBody({required this.clubId});
+  const _ClubOwnersBody({required this.clubId, this.isDialog = false});
 
   @override
-  State<_ClubOwnersBottomSheetBody> createState() => _ClubOwnersBottomSheetBodyState();
+  State<_ClubOwnersBody> createState() => _ClubOwnersBodyState();
 }
 
-class _ClubOwnersBottomSheetBodyState extends State<_ClubOwnersBottomSheetBody> {
+class _ClubOwnersBodyState extends State<_ClubOwnersBody> {
   late final OwnersRepository _ownersRepository;
 
   bool _isLoading = true;
@@ -49,6 +61,21 @@ class _ClubOwnersBottomSheetBodyState extends State<_ClubOwnersBottomSheetBody> 
 
   @override
   Widget build(BuildContext context) {
+    if (widget.isDialog) {
+      return CustomDialog(
+        child: SizedBox(
+          width: 480,
+          height: 600,
+          child: Column(
+            children: [
+              _buildHeader(context),
+              Expanded(child: _buildList(null)),
+            ],
+          ),
+        ),
+      );
+    }
+
     return DraggableScrollableSheet(
       initialChildSize: 0.7,
       minChildSize: 0.5,
@@ -56,82 +83,90 @@ class _ClubOwnersBottomSheetBodyState extends State<_ClubOwnersBottomSheetBody> 
       expand: false,
       builder: (_, scrollController) => Column(
         children: [
-          Container(
-            padding: const EdgeInsets.all(16),
-            decoration: BoxDecoration(
-              border: Border(
-                bottom: BorderSide(color: Colors.grey.shade300),
-              ),
-            ),
-            child: Row(
-              children: [
-                Text(
-                  context.locale.ownersTitle,
-                  style: MyTheme.of(context).headerTextStyle,
-                ),
-                const Spacer(),
-                IconButton(
-                  onPressed: _onAddOwner,
-                  icon: const Icon(Icons.add),
-                  tooltip: context.locale.ownersAddTitle,
-                ),
-                IconButton(
-                  onPressed: () => Navigator.pop(context),
-                  icon: const Icon(Icons.close),
-                ),
-              ],
-            ),
+          _buildHeader(context),
+          Expanded(child: _buildList(scrollController)),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildHeader(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        border: Border(
+          bottom: BorderSide(color: Colors.grey.shade300),
+        ),
+      ),
+      child: Row(
+        children: [
+          Text(
+            context.locale.ownersTitle,
+            style: MyTheme.of(context).headerTextStyle,
           ),
-          Expanded(
-            child: _isLoading
-                ? const Center(child: CircularProgressIndicator())
-                : _owners.isEmpty
-                    ? Center(
-                        child: Padding(
-                          padding: const EdgeInsets.all(16),
-                          child: Text(
-                            context.locale.ownersEmpty,
-                            textAlign: TextAlign.center,
-                            style: MyTheme.of(context).defaultTextStyle,
-                          ),
-                        ),
-                      )
-                    : ListView.builder(
-                        controller: scrollController,
-                        padding: const EdgeInsets.all(16),
-                        itemCount: _owners.length,
-                        itemBuilder: (context, index) {
-                          final owner = _owners[index];
-                          return Container(
-                            margin: const EdgeInsets.only(bottom: 8),
-                            padding: const EdgeInsets.all(12),
-                            decoration: BoxDecoration(
-                              border: Border.all(color: Colors.black26),
-                              borderRadius: BorderRadius.circular(8),
-                            ),
-                            child: Row(
-                              children: [
-                                Expanded(
-                                  child: Text(
-                                    owner.email,
-                                    style: MyTheme.of(context).defaultTextStyle,
-                                  ),
-                                ),
-                                IconButton(
-                                  onPressed: () => _onDeleteOwner(owner),
-                                  icon: Icon(
-                                    Icons.delete,
-                                    color: MyTheme.of(context).redColor,
-                                  ),
-                                ),
-                              ],
-                            ),
-                          );
-                        },
-                      ),
+          const Spacer(),
+          IconButton(
+            onPressed: _onAddOwner,
+            icon: const Icon(Icons.add),
+            tooltip: context.locale.ownersAddTitle,
+          ),
+          IconButton(
+            onPressed: () => Navigator.pop(context),
+            icon: const Icon(Icons.close),
           ),
         ],
       ),
+    );
+  }
+
+  Widget _buildList(ScrollController? scrollController) {
+    if (_isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (_owners.isEmpty) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Text(
+            context.locale.ownersEmpty,
+            textAlign: TextAlign.center,
+            style: MyTheme.of(context).defaultTextStyle,
+          ),
+        ),
+      );
+    }
+    return ListView.builder(
+      controller: scrollController,
+      padding: const EdgeInsets.all(16),
+      itemCount: _owners.length,
+      itemBuilder: (context, index) {
+        final owner = _owners[index];
+        return Container(
+          margin: const EdgeInsets.only(bottom: 8),
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            border: Border.all(color: Colors.black26),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  owner.email,
+                  style: MyTheme.of(context).defaultTextStyle,
+                ),
+              ),
+              IconButton(
+                onPressed: () => _onDeleteOwner(owner),
+                icon: Icon(
+                  Icons.delete,
+                  color: MyTheme.of(context).redColor,
+                ),
+              ),
+            ],
+          ),
+        );
+      },
     );
   }
 


### PR DESCRIPTION
## Описание

На desktop-версии меню настроек клуба (управление владельцами клуба — иконка-шестерёнка в шапке раздела клуба) раньше открывалось снизу как bottom sheet. Это уместно для мобильных, но на широких экранах выглядит чужеродно. Теперь на desktop оно открывается как отдельное центрированное модальное окно — в едином стиле с остальными desktop-диалогами приложения (например, «Описание клуба»).

## Поведение

| Платформа | Условие | Как открывается |
|-----------|---------|-----------------|
| Desktop | ширина >= 1050 (`!context.isMobile`) | Центрированное модальное окно (`CustomDialog`), фиксированный размер 480x600 |
| Mobile | ширина < 1050 | Выезжающий снизу `DraggableScrollableSheet` (bottom sheet) — без изменений |

## Детали реализации

- `ClubOwnersBottomSheet.show` теперь ветвится по `context.isMobile`: desktop -> `showDialog`, mobile -> `showModalBottomSheet`.
- Общее содержимое (заголовок с кнопками «добавить»/«закрыть» и список владельцев) вынесено в приватные методы `_buildHeader` / `_buildList` и переиспользуется в обоих вариантах раскладки.
- Бизнес-логика (загрузка, добавление, удаление владельцев) не изменена.
- Затронут только один файл: `lib/ui/main/club_page/widgets/club_owners_bottom_sheet.dart`.

## Проверки

- [x] `flutter analyze` по изменённому файлу — No issues found.
- [x] Приложение собирается и запускается на web (Chrome, debug).
- [ ] Ручная проверка открытия окна на desktop и bottom sheet на узком экране.

## Заметки

- В Flutter Web «отдельное окно» реализовано как модальное окно поверх приложения — это стандартный desktop-паттерн, уже используемый в проекте. Настоящее второе окно ОС средствами фреймворка недоступно.

🤖 Generated with [Claude Code](https://claude.com/claude-code)